### PR TITLE
Adds config.npm.enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ npm-pipeline-rails provides these configuration options:
 # These are defaults; in most cases, you don't need to configure anything.
 
 Rails.application.configure do
+  # Enable/disable npm_pipeline_rails. This allows other environments to use npm_pipeline_rails if required. Defaults to true if development.
+  config.npm.enable = Rails.env.development?
+
   # Command to install dependencies
   config.npm.install = ['npm install']
 

--- a/lib/npm-pipeline-rails/railtie.rb
+++ b/lib/npm-pipeline-rails/railtie.rb
@@ -33,6 +33,7 @@ module NpmPipelineRails
 
   class Railtie < ::Rails::Railtie
     config.npm = ActiveSupport::OrderedOptions.new
+    config.npm.enabled = ::Rails.env.development?
     config.npm.build = ['npm run build']
     config.npm.watch = ['npm run start']
     config.npm.install = ['npm install']
@@ -50,7 +51,7 @@ module NpmPipelineRails
     end
 
     initializer 'npm_pipeline.watch' do |app|
-      if ::Rails.env.development? && ::Rails.const_defined?(:Server)
+      if app.config.npm.enabled && ::Rails.const_defined?(:Server)
         Utils.do_system app.config.npm.install
         [*app.config.npm.watch].each do |cmd|
           Utils.background(cmd) { Utils.do_system [cmd] }


### PR DESCRIPTION
This adds support for non-development `(Rails.env.development?)` environments or better yet allows `npm-pipeline-rails` to run in different environments if needed for better debugging.