### PR TITLE
Add enable_watch flag (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ npm-pipeline-rails provides these configuration options:
 # These are defaults; in most cases, you don't need to configure anything.
 
 Rails.application.configure do
+  # Enable/disable npm_pipeline_rails. This allows other environments to use npm_pipeline_rails if required. Defaults to true if development.
+  config.npm.enable = Rails.env.development?
+
   # Command to install dependencies
   config.npm.install = ['npm install']
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ npm-pipeline-rails provides these configuration options:
 # These are defaults; in most cases, you don't need to configure anything.
 
 Rails.application.configure do
-  # Enable/disable npm_pipeline_rails. This allows other environments to use npm_pipeline_rails if required. Defaults to true if development.
-  config.npm.enable = Rails.env.development?
+  # Enables npm_pipeline_rails's invocation of `watch` commands.
+  # If `true`, watch commands will be ran alongside Rails's server.
+  # Defaults to true in development.
+  config.npm.enable_watch = Rails.env.development?
 
   # Command to install dependencies
   config.npm.install = ['npm install']

--- a/lib/npm-pipeline-rails/railtie.rb
+++ b/lib/npm-pipeline-rails/railtie.rb
@@ -33,7 +33,7 @@ module NpmPipelineRails
 
   class Railtie < ::Rails::Railtie
     config.npm = ActiveSupport::OrderedOptions.new
-    config.npm.enabled = ::Rails.env.development?
+    config.npm.enable_watch = ::Rails.env.development?
     config.npm.build = ['npm run build']
     config.npm.watch = ['npm run start']
     config.npm.install = ['npm install']
@@ -51,7 +51,7 @@ module NpmPipelineRails
     end
 
     initializer 'npm_pipeline.watch' do |app|
-      if app.config.npm.enabled && ::Rails.const_defined?(:Server)
+      if app.config.npm.enable_watch && ::Rails.const_defined?(:Server)
         Utils.do_system app.config.npm.install
         [*app.config.npm.watch].each do |cmd|
           Utils.background(cmd) { Utils.do_system [cmd] }

--- a/lib/npm-pipeline-rails/railtie.rb
+++ b/lib/npm-pipeline-rails/railtie.rb
@@ -33,6 +33,7 @@ module NpmPipelineRails
 
   class Railtie < ::Rails::Railtie
     config.npm = ActiveSupport::OrderedOptions.new
+    config.npm.enabled = ::Rails.env.development?
     config.npm.build = ['npm run build']
     config.npm.watch = ['npm run start']
     config.npm.install = ['npm install']
@@ -50,7 +51,7 @@ module NpmPipelineRails
     end
 
     initializer 'npm_pipeline.watch' do |app|
-      if ::Rails.env.development? && ::Rails.const_defined?(:Server)
+      if app.config.npm.enabled && ::Rails.const_defined?(:Server)
         Utils.do_system app.config.npm.install
         [*app.config.npm.watch].each do |cmd|
           Utils.background(cmd) { Utils.do_system [cmd] }


### PR DESCRIPTION
Continued off #7, thanks @jasontorres!

- Changes `config.npm.enable` to `config.npm.enable_watch`
- Fixes inconsistency in Readme.md