### PR TITLE
Allow skipping install

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm-pipeline-rails provides these configuration options:
 # These are defaults; in most cases, you don't need to configure anything.
 
 Rails.application.configure do
-  # Enables npm_pipeline_rails's invocation of `watch` commands.
+  # Enables npm_pipeline_rails's invocation of `watch` commands. (v1.5.0+)
   # If `true`, watch commands will be ran alongside Rails's server.
   # Defaults to true in development.
   config.npm.enable_watch = Rails.env.development?
@@ -99,6 +99,11 @@ Rails.application.configure do
     'npm run webpack:start',
     'npm run brunch:start'
   ]
+
+  # If 'true', runs 'npm install' on 'rake assets:precompile'. (v1.6.0+)
+  # This is generally desired, but you may set this to false when
+  # deploying to Heroku to speed things up.
+  config.npm.install_on_asset_precompile = true
 end
 ```
 

--- a/lib/npm-pipeline-rails/railtie.rb
+++ b/lib/npm-pipeline-rails/railtie.rb
@@ -37,12 +37,15 @@ module NpmPipelineRails
     config.npm.build = ['npm run build']
     config.npm.watch = ['npm run start']
     config.npm.install = ['npm install']
+    config.npm.install_on_asset_precompile = true
 
     rake_tasks do |app|
       namespace :assets do
         desc 'Build asset prerequisites using npm'
         task :npm_build do
-          Utils.do_system app.config.npm.install
+          if app.config.npm.install_on_asset_precompile
+            Utils.do_system app.config.npm.install
+          end
           Utils.do_system app.config.npm.build
         end
 


### PR DESCRIPTION
This will speed up your deploy times!

```rb
  # If 'true', runs 'npm install' on 'rake assets:precompile'. (v1.6.0+)
  # This is generally desired, but you may set this to false when
  # deploying to Heroku to speed things up.
  config.npm.install_on_asset_precompile = true
```