### PR TITLE
Don't explode if child process is already dead

### DIFF
--- a/lib/npm-pipeline-rails/railtie.rb
+++ b/lib/npm-pipeline-rails/railtie.rb
@@ -25,8 +25,12 @@ module NpmPipelineRails
 
       at_exit do
         Utils.log "Terminating '#{name}' [#{pid}]"
-        Process.kill 'TERM', pid
-        Process.wait pid
+        begin
+          Process.kill 'TERM', pid
+          Process.wait pid
+        rescue Errno::ESRCH, Errno::ECHILD => e
+          Utils.log "'#{name}' [#{pid}] already dead (#{e.class})"
+        end
       end
     end
   end


### PR DESCRIPTION
My brunch watcher is always, always already dead at this point (why? Will we ever know?)

Fixes #5 

Thanks!