### PR TITLE
Document config.npm.install_on_rails_server (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,14 @@ Rails.application.configure do
   ]
 
   # If 'true', runs 'npm install' on 'rake assets:precompile'. (v1.6.0+)
+  # If you disable this, you'll need to run `npm install` yourself.
   # This is generally desired, but you may set this to false when
   # deploying to Heroku to speed things up.
   config.npm.install_on_asset_precompile = true
+
+  # If 'true', runs 'npm install' on 'rails server'. (v1.7.0+)
+  # If you disable this, you'll need to run `npm install` yourself.
+  config.npm.install_on_rails_server = true
 end
 ```
 


### PR DESCRIPTION
Documents the option introduced in #12.

```rb
  # If 'true', runs 'npm install' on 'rails server'. (v1.7.0+)
  # If you disable this, you'll need to run `npm install` yourself.
  config.npm.install_on_rails_server = true
```